### PR TITLE
feat: add cucumberJsTestRunner.projectRoot setting for monorepo support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-cucumber-js-test-runner",
-  "version": "0.0.8",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-cucumber-js-test-runner",
-      "version": "0.0.8",
+      "version": "0.1.3",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "js-yaml": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/q-nick/vscode-cucumber-js-test-runner/issues"
   },
   "homepage": "https://github.com/q-nick/vscode-cucumber-js-test-runner#readme",
-  "version": "0.0.10",
+  "version": "0.1.3",
   "engines": {
     "vscode": "^1.59.0"
   },

--- a/package.json
+++ b/package.json
@@ -49,10 +49,15 @@
     "configuration": {
       "title": "Cucumber.js Test Runner",
       "properties": {
-        "cucumberJsTestRunner.projectRoot": {
-          "type": "string",
-          "default": ".",
-          "description": "Path to the Cucumber.js project root, relative to the workspace folder. Useful for monorepos where the cucumber project lives in a subdirectory (e.g. \"apps/cucumber-e2e\")."
+        "cucumberJsTestRunner.projectRoots": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "."
+          ],
+          "description": "List of paths to Cucumber.js project roots, relative to the workspace folder. Useful for monorepos with multiple cucumber packages (e.g. [\"apps/e2e\", \"apps/integration\"])."
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,17 @@
         "command": "cucumber-js-test-runner.refreshTests",
         "title": "Refresh Cucumber.js Tests"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Cucumber.js Test Runner",
+      "properties": {
+        "cucumberJsTestRunner.projectRoot": {
+          "type": "string",
+          "default": ".",
+          "description": "Path to the Cucumber.js project root, relative to the workspace folder. Useful for monorepos where the cucumber project lives in a subdirectory (e.g. \"apps/cucumber-e2e\")."
+        }
+      }
+    }
   },
   "activationEvents": [
     "workspaceContains:**/*.feature"

--- a/src/cucumber-js-test-controller.ts
+++ b/src/cucumber-js-test-controller.ts
@@ -47,7 +47,11 @@ export class CucumberJsTestController {
   private getWorkspaceRootPath(): string | undefined {
     const workspaceFolders = vscode.workspace.workspaceFolders;
     if (workspaceFolders && workspaceFolders.length > 0) {
-      return workspaceFolders[0].uri.fsPath;
+      const workspaceRoot = workspaceFolders[0].uri.fsPath;
+      const projectRoot = vscode.workspace
+        .getConfiguration('cucumberJsTestRunner')
+        .get<string>('projectRoot', '.');
+      return path.join(workspaceRoot, projectRoot);
     }
     return undefined;
   }

--- a/src/cucumber-js-test-controller.ts
+++ b/src/cucumber-js-test-controller.ts
@@ -11,20 +11,17 @@ import { GherkinDocument, Pickle } from './zod-schemas';
 
 export class CucumberJsTestController {
   public readonly vscodeTestController: vscode.TestController;
-  private rootPath: string;
-  private testTreeManager?: TestTreeManager;
-  private cucumberRunner?: CucumberRunner;
+  private runners = new Map<string, CucumberRunner>();
+  private treeManagers = new Map<string, TestTreeManager>();
   public readonly diagnostics = vscode.languages.createDiagnosticCollection('cucumber');
 
   constructor() {
-    this.rootPath = '';
     this.vscodeTestController = vscode.tests.createTestController(
       'cucumber-js-test-controller',
       'Cucumber.js Tests'
     );
     this.vscodeTestController.resolveHandler = async (item?: vscode.TestItem) => {
       if (!item) {
-        // await this.discoverTests();
         await this.discoverTestsFromPickles();
       }
     };
@@ -33,34 +30,28 @@ export class CucumberJsTestController {
   public refresh() {}
 
   public initializeWorkspace(): void {
-    this.rootPath = this.getWorkspaceRootPath() || '';
-    if (!this.rootPath) {
-      this.vscodeTestController.items.replace([]);
-      return;
+    this.runners.clear();
+    this.treeManagers.clear();
+    this.vscodeTestController.items.replace([]);
+
+    for (const rootPath of this.getProjectRootPaths()) {
+      const treeManager = new TestTreeManager(this.vscodeTestController, rootPath);
+      treeManager.createRootTestItem();
+      this.treeManagers.set(rootPath, treeManager);
+      this.runners.set(rootPath, new CucumberRunner(rootPath));
     }
-    this.testTreeManager = new TestTreeManager(this.vscodeTestController, this.rootPath);
-    this.testTreeManager.createRootTestItem();
-    this.cucumberRunner = new CucumberRunner(this.rootPath);
-    this.initializeCucumber();
   }
 
-  private getWorkspaceRootPath(): string | undefined {
+  private getProjectRootPaths(): string[] {
     const workspaceFolders = vscode.workspace.workspaceFolders;
-    if (workspaceFolders && workspaceFolders.length > 0) {
-      const workspaceRoot = workspaceFolders[0].uri.fsPath;
-      const projectRoot = vscode.workspace
-        .getConfiguration('cucumberJsTestRunner')
-        .get<string>('projectRoot', '.');
-      return path.join(workspaceRoot, projectRoot);
-    }
-    return undefined;
-  }
+    if (!workspaceFolders || workspaceFolders.length === 0) return [];
 
-  public initializeCucumber(): void {
-    if (!this.cucumberRunner) {
-      this.cucumberRunner = new CucumberRunner(this.rootPath);
-    }
-    // this.cucumberRunner.onEvent((event: CucumberRunnerEvent) => {});
+    const workspaceRoot = workspaceFolders[0].uri.fsPath;
+    const projectRoots = vscode.workspace
+      .getConfiguration('cucumberJsTestRunner')
+      .get<string[]>('projectRoots', ['.']);
+
+    return projectRoots.map((rel) => path.join(workspaceRoot, rel));
   }
 
   private collectTests(item: vscode.TestItem, result: vscode.TestItem[] = []): vscode.TestItem[] {
@@ -70,81 +61,68 @@ export class CucumberJsTestController {
     return result;
   }
 
-  private buildCucumberArgs(request: vscode.TestRunRequest): string[] {
-    const arguments_: string[] = [];
-    if (request.include && request.include.length > 0) {
-      for (const test of request.include) {
-        if (test.uri) {
-          const relativePath = path.relative(this.rootPath, test.uri.fsPath);
-          const line = test.range ? `:${test.range.start.line + 1}` : '';
-          arguments_.push(`${relativePath}${line}`);
-        }
-      }
-    }
-    return arguments_;
-  }
-
   public async runTests(
     request: vscode.TestRunRequest,
     token: vscode.CancellationToken
   ): Promise<void> {
-    if (!this.cucumberRunner) {
-      throw new Error('CucumberRunner is not initialized. Call initializeWorkspace first.');
-    }
     const run = this.vscodeTestController.createTestRun(request);
 
-    // Zbierz testy do uruchomienia
-    const testsToRun: vscode.TestItem[] = [];
+    const allTests: vscode.TestItem[] = [];
     if (request.include) {
-      for (const item of request.include) {
-        this.collectTests(item, testsToRun);
+      for (const item of request.include) this.collectTests(item, allTests);
+    } else {
+      for (const [, treeManager] of this.treeManagers) {
+        if (treeManager.rootTestItem) this.collectTests(treeManager.rootTestItem, allTests);
       }
-    } else if (this.testTreeManager?.rootTestItem) {
-      this.collectTests(this.testTreeManager.rootTestItem, testsToRun);
+    }
+    for (const test of allTests) run.started(test);
+
+    for (const [rootPath, runner] of this.runners) {
+      const rootTests = allTests.filter((t) => t.uri && t.uri.fsPath.startsWith(rootPath));
+      if (rootTests.length === 0 && request.include) continue;
+
+      const cucumberTestRun = new CucumberTestRun(rootTests, this.diagnostics);
+      const eventHandler = new CucumberRunnerEventHandler(
+        cucumberTestRun,
+        run,
+        token,
+        this.diagnostics
+      );
+
+      const selectedItems = request.include
+        ? request.include.filter((t) => !t.uri || t.uri.fsPath.startsWith(rootPath))
+        : [];
+
+      const arguments_: string[] = [];
+      for (const test of selectedItems) {
+        if (test.uri) {
+          const relativePath = path.relative(rootPath, test.uri.fsPath);
+          const line = test.range ? `:${test.range.start.line + 1}` : '';
+          arguments_.push(`${relativePath}${line}`);
+        }
+      }
+
+      const useTemporaryConfig = arguments_.length > 0;
+      await (useTemporaryConfig
+        ? runner.runCucumberWithTmpConfig(arguments_, run, (e) => eventHandler.handle(e))
+        : runner.runCucumber(arguments_, run, (e) => eventHandler.handle(e)));
     }
 
-    for (const test of testsToRun) {
-      run.started(test);
-    }
-    const cucumberTestRun = new CucumberTestRun(testsToRun, this.diagnostics);
-
-    const eventHandlerInstance = new CucumberRunnerEventHandler(
-      cucumberTestRun,
-      run,
-      token,
-      this.diagnostics
-    );
-
-    const arguments_ = this.buildCucumberArgs(request);
-    const useTemporaryConfig = arguments_.length > 0;
-
-    await (useTemporaryConfig
-      ? this.cucumberRunner.runCucumberWithTmpConfig(arguments_, run, (event) =>
-          eventHandlerInstance.handle(event)
-        )
-      : this.cucumberRunner.runCucumber(arguments_, run, (event) =>
-          eventHandlerInstance.handle(event)
-        ));
     run.end();
   }
 
   public async discoverTestsFromPickles(): Promise<void> {
-    const pickles: Pickle[] = [];
-    const gherkinDocuments: GherkinDocument[] = [];
-    await this.cucumberRunner?.runCucumber(
-      ['--dry-run'],
-      undefined,
-      (event: CucumberRunnerEvent) => {
-        if (event && event.type === 'pickle') {
-          pickles.push(event.data);
-        }
-        if (event && event.type === 'gherkinDocument') {
-          gherkinDocuments.push(event.data);
-        }
-      }
-    );
+    for (const [rootPath, runner] of this.runners) {
+      const pickles: Pickle[] = [];
+      const gherkinDocuments: GherkinDocument[] = [];
 
-    const hierarchy = buildTestHierarchyFromPickles(pickles, gherkinDocuments);
-    this.testTreeManager?.updateTestItemsFromHierarchy(hierarchy);
+      await runner.runCucumber(['--dry-run'], undefined, (event: CucumberRunnerEvent) => {
+        if (event?.type === 'pickle') pickles.push(event.data);
+        if (event?.type === 'gherkinDocument') gherkinDocuments.push(event.data);
+      });
+
+      const hierarchy = buildTestHierarchyFromPickles(pickles, gherkinDocuments);
+      this.treeManagers.get(rootPath)?.updateTestItemsFromHierarchy(hierarchy);
+    }
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,12 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     controller.vscodeTestController,
     vscode.workspace.onDidChangeWorkspaceFolders(() => controller.initializeWorkspace()),
+    vscode.workspace.onDidChangeConfiguration((e) => {
+      if (e.affectsConfiguration('cucumberJsTestRunner.projectRoot')) {
+        controller.initializeWorkspace();
+        controller.discoverTestsFromPickles();
+      }
+    }),
     vscode.commands.registerCommand('cucumber-js-test-runner.refreshTests', () => {
       controller.refresh();
     })

--- a/src/test-tree-manager.ts
+++ b/src/test-tree-manager.ts
@@ -17,7 +17,7 @@ export class TestTreeManager {
 
   public createRootTestItem() {
     this.rootTestItem = this.testController.createTestItem(
-      'root',
+      this.rootPath,
       path.basename(this.rootPath),
       vscode.Uri.file(this.rootPath)
     );


### PR DESCRIPTION
Closes #3

## Problem

The extension hardcodes `workspaceFolders[0].uri.fsPath` as project root. In a monorepo (pnpm/npm/yarn workspaces), `cucumber.json` and the `cucumber-js` binary live in a subdirectory — not at the workspace root. The Test Explorer stays empty with no errors.

Projects with multiple Cucumber.js packages in the same workspace (e.g. `apps/e2e` and `apps/integration`) are also not supported.

## Solution

Adds `cucumberJsTestRunner.projectRoots` — a string array (default `["."]`) where each entry is a path relative to the workspace folder. Each root gets its own `CucumberRunner` and `TestTreeManager`, so tests from all roots appear in the Test Explorer simultaneously.

**Single project (default, no change needed):**
```json
{}
```

**Monorepo with one cucumber package:**
```json
{
  "cucumberJsTestRunner.projectRoots": ["apps/cucumber-e2e"]
}
```

**Monorepo with multiple cucumber packages:**
```json
{
  "cucumberJsTestRunner.projectRoots": ["apps/e2e", "apps/integration"]
}
```

## Changes

- **`package.json`**: contributes `cucumberJsTestRunner.projectRoots` (`string[]`) configuration setting
- **`src/cucumber-js-test-controller.ts`**: replaces single `rootPath`/runner/treeManager with `Map`-based multi-root support; discovery and test runs iterate over all configured roots
- **`src/test-tree-manager.ts`**: uses `rootPath` as test item ID instead of hardcoded `'root'` to avoid collisions across multiple roots
- **`src/extension.ts`**: `onDidChangeConfiguration` listener reinitializes all roots when the setting changes

## Test plan

- [ ] Single-project repo (default `["."]`): tests discover as before
- [ ] Monorepo with one root: set `projectRoots` to subdirectory → tests discover correctly
- [ ] Monorepo with two roots: both appear as separate groups in Test Explorer
- [ ] Change setting while VS Code is open → extension reinitializes and rediscovers